### PR TITLE
Use $^X rather than "perl"

### DIFF
--- a/t/07-cfgexp.t
+++ b/t/07-cfgexp.t
@@ -13,7 +13,7 @@ use Test::More tests => 3;
 use strict;
 use warnings;
 
-my $cfgexp     = 'perl -Ilib bin/cfgver export';
+my $cfgexp     = '$^X -Ilib bin/cfgver export';
 my $gittestdir = qw( t/01-initdb.git );
 my $gittestdir2 = qw( t/05-config-merge.git );
 my $ver1 = '7dd8415a7e1cd131fba134c1da4c603ecf4974e2';

--- a/t/07-cfgexp.t
+++ b/t/07-cfgexp.t
@@ -13,7 +13,7 @@ use Test::More tests => 3;
 use strict;
 use warnings;
 
-my $cfgexp     = '$^X -Ilib bin/cfgver export';
+my $cfgexp     = "$^X -Ilib bin/cfgver export";
 my $gittestdir = qw( t/01-initdb.git );
 my $gittestdir2 = qw( t/05-config-merge.git );
 my $ver1 = '7dd8415a7e1cd131fba134c1da4c603ecf4974e2';


### PR DESCRIPTION
Thanks for your work on this module.
This short pull request changes the hardcoded "perl" to `$^X`:

https://rt.cpan.org/Public/Bug/Display.html?id=95263
